### PR TITLE
Fix relative links by removing "trailing slash"

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -45,6 +45,9 @@ const widgets = [
 export default defineConfig({
     site: 'https://aylur.github.io',
     base,
+    build: {
+        format: 'file',
+    },
     integrations: [
         starlight({
             title: 'AGS Wiki',


### PR DESCRIPTION
closes #4 

Astro's default `build.format` value is `"directory"`, 
so by default, `folder/example.md` in the source code becomes `folder/example/index.html` on the actual website.

That broke relative links that were supposed to be fixed by pull request #1

For example, a link going to `../ex2` from `folder/ex1` would go to  `ex2` in the source code (yay),
but a link going to `../ex2` from `folder/ex1/index.html` would go to `folder/ex2` in the actual website (not yay),
relative links are broken when Astro builds each source file as a directory.

So this pull request fixes that by setting `build.format` to `"file"`,
so for example, `folder/example.md` will now become `folder/example.html`, so relative links work again. (yay) 
