### PR TITLE
Fix relative links (again)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -46,7 +46,7 @@ export default defineConfig({
     site: 'https://aylur.github.io',
     base,
     build: {
-        format: 'file',
+        format: 'directory',
     },
     integrations: [
         starlight({

--- a/src/content/docs/config/services.md
+++ b/src/content/docs/config/services.md
@@ -62,13 +62,13 @@ Every service has a `"changed"` signal which is emitted
 on any kind of state change, unless stated otherwise.
 :::
 
-* [Applications](../services/applications)
-* [Audio](../services/audio)
-* [Battery](../services/battery)
-* [Bluetooth](../services/bluetooth)
-* [Hyprland](../services/hyprland)
-* [Mpris](../services/mpris)
-* [Network](../services/network)
-* [Notifications](../services/notifications)
-* [Power Profle](../services/power-profiles)
-* [System Tray](../services/systemtray)
+* [Applications](../../services/applications)
+* [Audio](../../services/audio)
+* [Battery](../../services/battery)
+* [Bluetooth](../../services/bluetooth)
+* [Hyprland](../../services/hyprland)
+* [Mpris](../../services/mpris)
+* [Network](../../services/network)
+* [Notifications](../../services/notifications)
+* [Power Profle](../../services/power-profiles)
+* [System Tray](../../services/systemtray)


### PR DESCRIPTION
Astro's `link` field in the sidebar automatically adds `.html` if `build.format` is `"file"`,
that should be okay, but it means any link to a header `folder/page#header` becomes `folder/page#header.html`.

You can't change that in astro's config, so this pull request sets `build.format` back to `"directory"`, and changes relative links to work with that.

This also closes #6

Adding an extra `../` is annoying, and #5 would have fixed that, but because of how astro works, this is the only way to make everything work properly.
