### PR TITLE
fix utils.execAsync example error

### DIFF
--- a/src/content/docs/config/utils.md
+++ b/src/content/docs/config/utils.md
@@ -52,7 +52,7 @@ meaning if you want to use `|` pipes or any other shell
 operator then you have to run it with bash.
 
 ```js
-Utils.execAsync(['bash', '-c', ['something | something && something']);
+Utils.execAsync(['bash', '-c', 'something | something && something']);
 Utils.exec('bash -c "something | something && something"');
 ```
 


### PR DESCRIPTION
delete a extra left square bracket