### PR TITLE
Typo in custom-service.md

### DIFF
--- a/src/content/docs/config/custom-service.md
+++ b/src/content/docs/config/custom-service.md
@@ -109,7 +109,7 @@ import Widget from 'resource:///com/github/Aylur/ags/widget.js';
 import Brightness from './brightness.js';
 
 const slider = Widget.Slider({
-    on_change: self => service.screen_value = self.value,
+    on_change: self => Brightness.screen_value = self.value,
     value: Brightness.bind('screen-value'),
 });
 


### PR DESCRIPTION
In some example code it said `service.screen_value`, but its supposed to be `Brightness.screen_value`, so i fixed it :3