### PR TITLE
fix(app): update broken link for Example Notification Popups

### DIFF
--- a/src/content/docs/services/notifications.md
+++ b/src/content/docs/services/notifications.md
@@ -49,4 +49,4 @@ title: Notifications
 * `close` `() => void`
 * `invoke` `(actionId: string) => void` invoking an action will also close the notification
 
-## [Example Notification Center](https://github.com/Aylur/ags/tree/main/example/notification-center)
+## [Example Notification Popups](https://github.com/Aylur/ags/tree/main/example/notification-popups)


### PR DESCRIPTION
Corrected the broken link that pointed to '**example/notification-center**' and replaced it with the correct path '**example/notification-popups**'.

![img github](https://0x0.st/HGJf.png)

![img devtools](https://0x0.st/HGJO.png)