### PR TITLE
docs: fix code example for window options

### DIFF
--- a/src/content/docs/config/widgets.md
+++ b/src/content/docs/config/widgets.md
@@ -78,7 +78,7 @@ subclass of [Gtk.Window](https://gjs-docs.gnome.org/gtk30~3.0/gtk.window)
 const window = Widget.Window({
     name: 'window-name',
     anchor: ['top', 'left', 'right'],
-    exclusive: false,
+    exclusivity: 'normal',
     keymode: 'on-demand',
     layer: 'top',
     margin: [0, 6],


### PR DESCRIPTION
Corrected the code example showing `Widget.Window` configuration with `exclusive` option instead of `exclusivity` as the docs shows.

- **doc option**:

![image](https://github.com/Aylur/ags-docs/assets/76636791/255a6685-0594-4531-8de5-c290ae0b66da)

- **old example**:

![image](https://github.com/Aylur/ags-docs/assets/76636791/6f76b8e8-4f7c-4aa6-ad27-fde0a28f2062)

- **new example**:

![image](https://github.com/Aylur/ags-docs/assets/76636791/c1ba67fa-50e9-4a73-b4bf-3a2a10d27dad)
