### PR TITLE
theming.md: add a warning about `Utils.monitorFile` and infinite loops

### DIFF
--- a/src/content/docs/config/theming.md
+++ b/src/content/docs/config/theming.md
@@ -97,7 +97,7 @@ Utils.monitorFile(
         const scss = `${App.configDir}/style.scss`
 
         // target css file
-        const css = `${App.configDir}/style.css`
+        const css = `/tmp/ags/style.css`
 
         // compile, reset, apply
         Utils.exec(`sassc ${scss} ${css}`)
@@ -109,3 +109,4 @@ Utils.monitorFile(
     'directory',
 )
 ```
+


### PR DESCRIPTION
I imagine it's something obvious anyways but still there'd definitely be some folks who wouldn't consider it.