### PR TITLE
docs: add warning for monitoring pseudo filesystems

### DIFF
--- a/src/content/docs/config/custom-service.md
+++ b/src/content/docs/config/custom-service.md
@@ -100,6 +100,15 @@ const service = new BrightnessService;
 export default service;
 ```
 
+:::caution
+`Utils.monitorFile` only reports events that a user-space program 
+triggers through the filesystem API. As a result, it does not catch
+remote events that occur on network filesystems.
+Furthermore, most pseudo-filesystems such as `/proc`, `/sys` and `/dev/pts`
+cannot be monitored.
+:::
+
+
 :::note
 For `bind` to work, the property has to be defined in `Service.register`
 :::

--- a/src/content/docs/config/utils.md
+++ b/src/content/docs/config/utils.md
@@ -131,6 +131,14 @@ const monitor = Utils.monitorFile('/path/to/file', (file, event) => {
 })
 ```
 
+:::caution
+`monitorFile` only reports events that a user-space program 
+triggers through the filesystem API. As a result, it does not catch
+remote events that occur on network filesystems.
+Furthermore, most pseudo-filesystems such as `/proc`, `/sys` and `/dev/pts`
+cannot be monitored.
+:::
+
 ### Canceling the monitor
 
 ```js


### PR DESCRIPTION
Warn users of trying to monitor pseudo filesystems.