### PR TITLE
Fix variable typo: `cound` -> `count`

### DIFF
--- a/src/content/docs/config/subclassing-gtk-widgets.md
+++ b/src/content/docs/config/subclassing-gtk-widgets.md
@@ -58,7 +58,7 @@ function CounterButton(({ color = 'aqua', ...rest })) {
     return Widget.Button({
         ...rest, // spread passed parameters
         child: label,
-        onClicked: () => cound++,
+        onClicked: () => count++,
     })
 }
 


### PR DESCRIPTION
Fixed a typo in the "Subclassing GTK Widgets" page! This PR is pretty self-explanatory...