### PR TITLE
fix typo on line 404 where label content is "label" instead of "hello"

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -47,7 +47,7 @@ const widgets = [
     'MenuItem',
     'OverLay',
     'ProgressBar',
-    'Reveale',
+    'Revealer',
     'Scrollable',
     'Separator',
     'Slider',

--- a/src/content/docs/config/widgets.md
+++ b/src/content/docs/config/widgets.md
@@ -401,7 +401,7 @@ const label = Widget.Label({
 })
 
 // shorthand for { label: 'hello' }
-Widget.Label('label')
+Widget.Label('hello')
 ```
 
 ### LevelBar


### PR DESCRIPTION
![image](https://github.com/Aylur/ags-docs/assets/110229646/e18b72ab-9999-4bd9-af3b-3223a67d9a3f)
