### PR TITLE
fix typo in docs

### DIFF
--- a/src/content/docs/config/services.md
+++ b/src/content/docs/config/services.md
@@ -99,5 +99,5 @@ on any kind of state change, unless stated otherwise.
 * [mpris](../../services/mpris)
 * [network](../../services/network)
 * [notifications](../../services/notifications)
-* [powerprofles](../../services/powerprofiles)
+* [powerprofiles](../../services/powerprofiles)
 * [systemtray](../../services/systemtray)


### PR DESCRIPTION
at the bottom of this page.
https://aylur.github.io/ags-docs/config/services/

changed powerprofles to powerprofiles.