### PR TITLE
For greetd example, window needs keymode: exclusive

### DIFF
--- a/src/content/docs/services/greetd.md
+++ b/src/content/docs/services/greetd.md
@@ -54,6 +54,7 @@ const response = Widget.Label()
 const win = Widget.Window({
     css: 'background-color: transparent;',
     anchor: ['top', 'left', 'right', 'bottom'],
+    keymode: 'exclusive',
     child: Widget.Box({
         vertical: true,
         hpack: 'center',


### PR DESCRIPTION
First time user so I may be wrong, but it seems that in order for this to accept any keyboard input, the window needs to have keymode: exclusive set. See https://discord.com/channels/1143610930542944377/1143612651759489054/1253713864244330551 for more info.