### PR TITLE
Fixed typo in widgets.md

### DIFF
--- a/src/content/docs/config/widgets.md
+++ b/src/content/docs/config/widgets.md
@@ -577,7 +577,7 @@ any additional properties/methods on top of the base Gtk widget.
 ```js
 const menubar = Widget.MenuBar({
     setup: self => {
-        self.append(Widget.Mene())
+        self.append(Widget.Menu())
     }
 })
 ```


### PR DESCRIPTION
Fixed typo in code snippet.

```diff
- Widget.Mene()
+ Widget.Menu()
```